### PR TITLE
group/switch/puppet で外部アニメーションを、 raw で生成アニメーションを使えるようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "archery"
@@ -162,7 +162,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "declavatar"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "either",
  "ketos",
@@ -702,7 +702,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.41"
+version = "2.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
+checksum = "5b7d0a2c048d661a1a59fcd7355baa232f7ed34e0ee4df2eef3c1c1c0d3852d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -807,7 +807,7 @@ checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.42",
 ]
 
 [[package]]

--- a/declavatar/Cargo.toml
+++ b/declavatar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declavatar"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [features]

--- a/declavatar/src/avatar_v2/data/layer.rs
+++ b/declavatar/src/avatar_v2/data/layer.rs
@@ -23,7 +23,7 @@ pub enum LayerContent {
     },
     Puppet {
         parameter: String,
-        keyframes: Vec<LayerPuppetKeyframe>,
+        animation: LayerAnimation,
     },
     Raw {
         default_index: usize,
@@ -127,6 +127,7 @@ pub enum LayerRawCondition {
 #[serde(tag = "type", content = "content")]
 pub enum LayerAnimation {
     Inline(Vec<Target>),
+    KeyedInline(Vec<LayerPuppetKeyframe>),
     External(String),
 }
 

--- a/declavatar/src/avatar_v2/data/layer.rs
+++ b/declavatar/src/avatar_v2/data/layer.rs
@@ -73,7 +73,7 @@ pub struct LayerRawState {
 }
 
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", content = "content")]
 pub enum LayerRawAnimationKind {
     Clip {
         animation: LayerAnimation,

--- a/declavatar/src/avatar_v2/data/layer.rs
+++ b/declavatar/src/avatar_v2/data/layer.rs
@@ -76,7 +76,7 @@ pub struct LayerRawState {
 #[serde(tag = "type")]
 pub enum LayerRawAnimation {
     Clip {
-        name: LayerAnimation,
+        animation: LayerAnimation,
         speed: Option<f64>,
         speed_by: Option<String>,
         time_by: Option<String>,
@@ -139,5 +139,11 @@ impl Target {
             Target::ParameterDrive(pd) => format!("parameter://{}", pd.target_parameter()),
             Target::TrackingControl(tc) => format!("tracking://{:?}", tc.target),
         }
+    }
+}
+
+impl Default for LayerAnimation {
+    fn default() -> Self {
+        LayerAnimation::Inline(vec![])
     }
 }

--- a/declavatar/src/avatar_v2/data/layer.rs
+++ b/declavatar/src/avatar_v2/data/layer.rs
@@ -69,12 +69,12 @@ pub enum Target {
 #[derive(Debug, Clone, Serialize)]
 pub struct LayerRawState {
     pub name: String,
-    pub animation: LayerRawAnimation,
+    pub animation: LayerRawAnimationKind,
 }
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
-pub enum LayerRawAnimation {
+pub enum LayerRawAnimationKind {
     Clip {
         animation: LayerAnimation,
         speed: Option<f64>,

--- a/declavatar/src/avatar_v2/data/layer.rs
+++ b/declavatar/src/avatar_v2/data/layer.rs
@@ -18,8 +18,8 @@ pub enum LayerContent {
     },
     Switch {
         parameter: String,
-        disabled: Vec<Target>,
-        enabled: Vec<Target>,
+        disabled: LayerAnimation,
+        enabled: LayerAnimation,
     },
     Puppet {
         parameter: String,
@@ -36,7 +36,7 @@ pub enum LayerContent {
 pub struct LayerGroupOption {
     pub name: String,
     pub value: usize,
-    pub targets: Vec<Target>,
+    pub animation: LayerAnimation,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -76,7 +76,7 @@ pub struct LayerRawState {
 #[serde(tag = "type")]
 pub enum LayerRawAnimation {
     Clip {
-        name: String,
+        name: LayerAnimation,
         speed: Option<f64>,
         speed_by: Option<String>,
         time_by: Option<String>,
@@ -96,9 +96,9 @@ pub enum LayerRawBlendTreeType {
     Cartesian2D,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LayerRawField {
-    pub name: String,
+    pub animation: LayerAnimation,
     pub position: [f64; 2],
 }
 
@@ -121,6 +121,13 @@ pub enum LayerRawCondition {
     LeInt(String, i64),
     GtFloat(String, f64),
     LeFloat(String, f64),
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", content = "content")]
+pub enum LayerAnimation {
+    Inline(Vec<Target>),
+    External(String),
 }
 
 impl Target {

--- a/declavatar/src/avatar_v2/logger.rs
+++ b/declavatar/src/avatar_v2/logger.rs
@@ -94,6 +94,7 @@ pub enum Log {
     LayerMustBePuppet(String),
     LayerMustBeRaw(String),
     LayerOptionNotFound(String),
+    LayerOptionMustBeExclusive,
     LayerDisabledTargetFailure(String),
     LayerMaterialFailure(usize),
     LayerIndeterminateShapeChange(String),
@@ -163,6 +164,12 @@ impl Display for Log {
             }
             Log::LayerOptionNotFound(option) => {
                 write!(f, "option '{option}' not found")
+            }
+            Log::LayerOptionMustBeExclusive => {
+                write!(
+                    f,
+                    "external animation asset cannot be combined with targets"
+                )
             }
             Log::LayerDisabledTargetFailure(target) => {
                 write!(f, "target '{target}' has no auto-generated disabled target")

--- a/declavatar/src/avatar_v2/logger.rs
+++ b/declavatar/src/avatar_v2/logger.rs
@@ -100,6 +100,7 @@ pub enum Log {
     LayerIndeterminateShapeChange(String),
     LayerIndeterminateMaterialChange(usize),
     LayerPuppetCannotDrive,
+    LayerPuppetOptionMustBeInlined,
     LayerKeyframeOutOfRange(f64),
     LayerStateNotFound(String),
     LayerBlendTreeParameterNotFound(String),
@@ -185,6 +186,9 @@ impl Display for Log {
             }
             Log::LayerPuppetCannotDrive => {
                 write!(f, "puppet layer cannot drive parameters")
+            }
+            Log::LayerPuppetOptionMustBeInlined => {
+                write!(f, "puppet option cannot be external animation")
             }
             Log::LayerKeyframeOutOfRange(value) => {
                 write!(f, "puppet layer value out of range: {value}")

--- a/declavatar/src/avatar_v2/transformer/layer.rs
+++ b/declavatar/src/avatar_v2/transformer/layer.rs
@@ -115,12 +115,12 @@ pub fn compile_group_layer(
         Some(Some((None, None, targets))) => LayerGroupOption {
             name: "<default>".to_string(),
             value: 0,
-            targets,
+            animation: targets,
         },
         _ => LayerGroupOption {
             name: "<default>".to_string(),
             value: 0,
-            targets: vec![],
+            animation: vec![],
         },
     };
 
@@ -138,7 +138,7 @@ pub fn compile_group_layer(
         options.push(LayerGroupOption {
             name,
             value: explicit_index.unwrap_or(index + 1),
-            targets,
+            animation: targets,
         });
     }
 
@@ -524,7 +524,7 @@ fn compile_raw_animation(
             for decl_field in decl_fields {
                 first_pass.find_asset(logger, &decl_field.name, AssetType::Animation)?;
                 fields.push(LayerRawField {
-                    name: decl_field.name,
+                    animation: decl_field.name,
                     position: decl_field.values,
                 });
             }

--- a/declavatar/src/avatar_v2/transformer/layer.rs
+++ b/declavatar/src/avatar_v2/transformer/layer.rs
@@ -590,7 +590,7 @@ fn compile_raw_animation(
             let mut compiled_targets = BTreeMap::new();
             for decl_target in targets.targets {
                 let Some(targets) =
-                    compile_target(&logger, first_pass, None, UnsetValue::Active, decl_target)
+                    compile_target(logger, first_pass, None, UnsetValue::Active, decl_target)
                 else {
                     continue;
                 };

--- a/declavatar/src/decl_v2/data/layer.rs
+++ b/declavatar/src/decl_v2/data/layer.rs
@@ -87,6 +87,7 @@ pub struct DeclPuppetLayer {
     pub name: String,
     pub driven_by: String,
     pub default_mesh: Option<String>,
+    pub animation_asset: Option<String>,
     pub keyframes: Vec<DeclGroupOption>,
 }
 static_type_name_impl!(DeclPuppetLayer);

--- a/declavatar/src/decl_v2/data/layer.rs
+++ b/declavatar/src/decl_v2/data/layer.rs
@@ -27,6 +27,7 @@ static_type_name_impl!(DeclGroupLayer);
 #[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
 pub struct DeclGroupOption {
     pub kind: DeclGroupOptionKind,
+    pub animation_asset: Option<String>,
     pub targets: Vec<DeclGroupOptionTarget>,
 }
 static_type_name_impl!(DeclGroupOption);

--- a/declavatar/src/decl_v2/data/layer.rs
+++ b/declavatar/src/decl_v2/data/layer.rs
@@ -103,15 +103,15 @@ static_type_name_impl!(DeclRawLayer);
 #[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
 pub struct DeclRawLayerState {
     pub name: String,
-    pub animation: DeclRawLayerAnimation,
+    pub kind: DeclRawLayerAnimationKind,
     pub transitions: Vec<DeclRawLayerTransition>,
 }
 static_type_name_impl!(DeclRawLayerState);
 
 #[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
-pub enum DeclRawLayerAnimation {
+pub enum DeclRawLayerAnimationKind {
     Clip {
-        name: String,
+        animation: DeclRawLayerAnimation,
         speed: (Option<f64>, Option<String>),
         time: Option<String>,
     },
@@ -132,10 +132,22 @@ pub enum DeclRawLayerBlendTreeType {
 
 #[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
 pub struct DeclRawLayerBlendTreeField {
-    pub name: String,
+    pub animation: DeclRawLayerAnimation,
     pub values: [f64; 2],
 }
 static_type_name_impl!(DeclRawLayerBlendTreeField);
+
+#[derive(Debug, Clone)]
+pub enum DeclRawLayerAnimation {
+    Inline(DeclLayerInlineAnimation),
+    External(String),
+}
+
+#[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
+pub struct DeclLayerInlineAnimation {
+    pub targets: Vec<DeclGroupOptionTarget>,
+}
+static_type_name_impl!(DeclLayerInlineAnimation);
 
 #[derive(Debug, Clone, ForeignValue, FromValue, FromValueRef, IntoValue)]
 pub struct DeclRawLayerTransition {

--- a/declavatar/src/decl_v2/sexpr/da/layer.rs
+++ b/declavatar/src/decl_v2/sexpr/da/layer.rs
@@ -4,9 +4,10 @@ use crate::decl_v2::{
         layer::{
             DeclControllerLayer, DeclGroupLayer, DeclGroupMaterialTarget, DeclGroupObjectTarget,
             DeclGroupOption, DeclGroupOptionKind, DeclGroupOptionTarget, DeclGroupShapeTarget,
-            DeclPuppetLayer, DeclRawLayer, DeclRawLayerAnimation, DeclRawLayerBlendTreeField,
-            DeclRawLayerBlendTreeType, DeclRawLayerState, DeclRawLayerTransition,
-            DeclRawLayerTransitionCondition, DeclRawLayerTransitionOrdering, DeclSwitchLayer,
+            DeclLayerInlineAnimation, DeclPuppetLayer, DeclRawLayer, DeclRawLayerAnimation,
+            DeclRawLayerAnimationKind, DeclRawLayerBlendTreeField, DeclRawLayerBlendTreeType,
+            DeclRawLayerState, DeclRawLayerTransition, DeclRawLayerTransitionCondition,
+            DeclRawLayerTransitionOrdering, DeclSwitchLayer,
         },
         StaticTypeName,
     },
@@ -57,6 +58,13 @@ pub fn register_layer_function(scope: &Scope) {
         declare_option,
         Arity::Min(1),
         &["value", "animation"],
+    );
+    register_function(
+        scope,
+        "inline-animation",
+        declare_inline_animation,
+        Arity::Min(0),
+        &[],
     );
     register_function(scope, "state", declare_state, Arity::Min(2), &[]);
 
@@ -406,7 +414,7 @@ fn declare_state(
     args: SeparateArguments,
 ) -> KetosResult<Value> {
     let name: &str = args.exact_arg(function_name, 0)?;
-    let animation: &DeclRawLayerAnimation = args.exact_arg(function_name, 1)?;
+    let kind: &DeclRawLayerAnimationKind = args.exact_arg(function_name, 1)?;
 
     let mut transitions = vec![];
     for transition_value in args.args_after(function_name, 2)? {
@@ -416,10 +424,23 @@ fn declare_state(
 
     Ok(DeclRawLayerState {
         name: name.to_string(),
-        animation: animation.clone(),
+        kind: kind.clone(),
         transitions,
     }
     .into())
+}
+
+fn declare_inline_animation(
+    _name_store: &NameStore,
+    function_name: Name,
+    args: SeparateArguments,
+) -> KetosResult<Value> {
+    let mut targets = vec![];
+    for target_value in args.args_after(function_name, 0)? {
+        targets.push(take_option_target(target_value)?);
+    }
+
+    Ok(DeclLayerInlineAnimation { targets }.into())
 }
 
 fn declare_clip(
@@ -427,13 +448,13 @@ fn declare_clip(
     function_name: Name,
     args: SeparateArguments,
 ) -> KetosResult<Value> {
-    let name: &str = args.exact_arg(function_name, 0)?;
+    let animation: &Value = args.exact_arg(function_name, 0)?;
     let speed: Option<f64> = args.exact_kwarg("speed")?;
     let speed_by: Option<&str> = args.exact_kwarg("speed-by")?;
     let time_by: Option<&str> = args.exact_kwarg("time-by")?;
 
-    Ok(DeclRawLayerAnimation::Clip {
-        name: name.to_string(),
+    Ok(DeclRawLayerAnimationKind::Clip {
+        animation: take_animation(animation)?,
         speed: (speed, speed_by.map(|s| s.to_string())),
         time: time_by.map(|t| t.to_string()),
     }
@@ -488,7 +509,7 @@ fn declare_blendtree(
         fields.push(field.clone());
     }
 
-    Ok(DeclRawLayerAnimation::BlendTree { tree_type, fields }.into())
+    Ok(DeclRawLayerAnimationKind::BlendTree { tree_type, fields }.into())
 }
 
 fn declare_blendtree_field(
@@ -496,15 +517,42 @@ fn declare_blendtree_field(
     function_name: Name,
     args: SeparateArguments,
 ) -> KetosResult<Value> {
-    let name: &str = args.exact_arg(function_name, 0)?;
+    let animation: &Value = args.exact_arg(function_name, 0)?;
     let x_value: Option<f64> = args.try_exact_arg(1)?;
     let y_value: Option<f64> = args.try_exact_arg(2)?;
 
     Ok(DeclRawLayerBlendTreeField {
-        name: name.to_string(),
+        animation: take_animation(animation)?,
         values: [x_value.unwrap_or(0.0), y_value.unwrap_or(0.0)],
     }
     .into())
+}
+
+fn take_animation(animation_value: &Value) -> KetosResult<DeclRawLayerAnimation> {
+    let target = match animation_value.type_name() {
+        "string" => {
+            let Value::String(s) = animation_value else {
+                unreachable!("must be string")
+            };
+            DeclRawLayerAnimation::External(s.to_string())
+        }
+        DeclLayerInlineAnimation::TYPE_NAME => DeclRawLayerAnimation::Inline(
+            animation_value
+                .downcast_foreign_ref::<&DeclLayerInlineAnimation>()?
+                .clone(),
+        ),
+        _ => {
+            return Err(Error::Custom(
+                DeclSexprError::UnexpectedTypeValue(
+                    animation_value.type_name().to_string(),
+                    "string or inline animation".to_string(),
+                )
+                .into(),
+            ))
+        }
+    };
+
+    Ok(target)
 }
 
 fn declare_transition_to(

--- a/declavatar/src/decl_v2/sexpr/da/layer.rs
+++ b/declavatar/src/decl_v2/sexpr/da/layer.rs
@@ -40,7 +40,7 @@ pub fn register_layer_function(scope: &Scope) {
         "puppet-layer",
         declare_puppet_layer,
         Arity::Min(1),
-        &["driven-by", "default-mesh"],
+        &["driven-by", "default-mesh", "animation"],
     );
     register_function(
         scope,
@@ -216,6 +216,7 @@ fn declare_puppet_layer(
     let name: &str = args.exact_arg(function_name, 0)?;
     let driven_by: &str = args.exact_kwarg_expect("driven-by")?;
     let default_mesh: Option<&str> = args.exact_kwarg("default-mesh")?;
+    let animation_asset: Option<&str> = args.exact_kwarg("animation")?;
 
     let mut keyframes = vec![];
     for option_value in args.args_after(function_name, 1)? {
@@ -238,6 +239,7 @@ fn declare_puppet_layer(
         name: name.to_string(),
         driven_by: driven_by.to_string(),
         default_mesh: default_mesh.map(|dm| dm.to_string()),
+        animation_asset: animation_asset.map(|a| a.to_string()),
         keyframes,
     })
     .into())

--- a/declavatar/src/decl_v2/sexpr/da/layer.rs
+++ b/declavatar/src/decl_v2/sexpr/da/layer.rs
@@ -51,7 +51,13 @@ pub fn register_layer_function(scope: &Scope) {
     );
 
     // option functions
-    register_function(scope, "option", declare_option, Arity::Min(1), &["value"]);
+    register_function(
+        scope,
+        "option",
+        declare_option,
+        Arity::Min(1),
+        &["value", "animation"],
+    );
     register_function(scope, "state", declare_state, Arity::Min(2), &[]);
 
     // set-x functions
@@ -287,13 +293,19 @@ fn declare_option(
             }));
         }
     };
+    let animation_asset: Option<&str> = args.exact_kwarg("animation")?;
 
     let mut targets = vec![];
     for target_value in args.args_after(function_name, 1)? {
         targets.push(take_option_target(target_value)?);
     }
 
-    Ok(DeclGroupOption { kind, targets }.into())
+    Ok(DeclGroupOption {
+        kind,
+        animation_asset: animation_asset.map(|a| a.to_string()),
+        targets,
+    }
+    .into())
 }
 
 pub fn take_option_target(target_value: &Value) -> KetosResult<DeclGroupOptionTarget> {

--- a/declavatar/src/decl_v2/sexpr/dain/option.rs
+++ b/declavatar/src/decl_v2/sexpr/dain/option.rs
@@ -136,6 +136,7 @@ fn option_replace_targets(
 
     Ok(DeclGroupOption {
         kind: original_option.kind.clone(),
+        animation_asset: original_option.animation_asset.clone(),
         targets,
     }
     .into())

--- a/examples/sexpr/universal-animation.declisp
+++ b/examples/sexpr/universal-animation.declisp
@@ -1,0 +1,40 @@
+; vim: set ft=commonlisp
+(use da :self)
+
+(da/avatar "universal-animation"
+    (da/parameters
+        (da/int "group-index")
+        (da/bool "switch" :scope 'local)
+    )
+
+    (da/assets
+        (da/animation "group-animation-1")
+        (da/animation "group-animation-2")
+    )
+
+    (da/fx-controller
+        (da/group-layer "group-universal"
+            :driven-by "group-index"
+            (da/option "option1" :animation "group-animation-1")
+            (da/option "option2" :animation "group-animation-2")
+        )
+
+        (da/raw-layer "raw-universal"
+            :default "state1"
+            (da/state "state1"
+                (da/clip (da/inline-animation
+                    (da/set-tracking 'tracking 'mouth)
+                    (da/set-object "Hat" false)
+                ))
+                (da/transition-to "state2" '(= "switch" true))
+            )
+            (da/state "state2"
+                (da/clip (da/inline-animation
+                    (da/set-tracking 'animation 'mouth)
+                    (da/set-object "Hat" true)
+                ))
+                (da/transition-to "state1" '(= "switch" false))
+            )
+        )
+    )
+)

--- a/examples/sexpr/universal-animation.declisp
+++ b/examples/sexpr/universal-animation.declisp
@@ -24,14 +24,14 @@
             (da/state "state1"
                 (da/clip (da/inline-animation
                     (da/set-tracking 'tracking 'mouth)
-                    (da/set-object "Hat" false)
+                    (da/set-object "Hat" :value false)
                 ))
                 (da/transition-to "state2" '(= "switch" true))
             )
             (da/state "state2"
                 (da/clip (da/inline-animation
                     (da/set-tracking 'animation 'mouth)
-                    (da/set-object "Hat" true)
+                    (da/set-object "Hat" :value true)
                 ))
                 (da/transition-to "state1" '(= "switch" false))
             )


### PR DESCRIPTION
* よく考えたら別にここを分断させる意味はなく、実装上の都合でしかなかった
* 言い訳するならば KDL は entries にノードを持たせられなかったので、asset key を受ける代わりに option を受けるみたいなことがやりづらかった